### PR TITLE
fix: upgrade Next.js to 16.1.6 to resolve url.parse() deprecation warning

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -16,7 +16,7 @@
     "axios": "^1.13.6",
     "better-auth": "^1.4.10",
     "lucide-react": "^0.562.0",
-    "next": "16.1.1",
+    "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
@@ -26,7 +26,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "16.1.1",
+    "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Problem Summary
The frontend application was showing a Node.js DEP0169 deprecation warning about `url.parse()` when running with Node.js 25.x. This warning indicates that the deprecated `url.parse()` API is being used somewhere in the dependency chain, which has security implications.

## Solution Approach
Upgraded Next.js from version 16.1.1 to 16.1.6, which includes fixes for the deprecated `url.parse()` usage. Also updated `eslint-config-next` to match the Next.js version.

## Changes Made
- Updated `next` from 16.1.1 to 16.1.6
- Updated `eslint-config-next` from 16.1.1 to 16.1.6

## Test Evidence
The deprecation warning should no longer appear when running `npm run dev` with Node.js 25.x. The upgrade is a minor patch release that maintains backward compatibility.

## References
- Fixes #1
- Related Next.js issues: vercel/next.js#83183, vercel/next.js#86951